### PR TITLE
fix: populate ingredient names in recipes

### DIFF
--- a/src/controllers/recipes.js
+++ b/src/controllers/recipes.js
@@ -127,7 +127,13 @@ export const removeFromFavoritesController = async (req, res) => {
 
 export const getFavoriteRecipesController = async (req, res, next) => {
   try {
-    const user = await UserModel.findById(req.user.id).populate('favorites');
+    const user = await UserModel.findById(req.user.id).populate({
+      path: 'favorites',
+      populate: {
+        path: 'ingredients.id',
+        select: '-__v',
+      },
+    });
 
     if (!user) {
       throw new createHttpError.NotFound('User not found');

--- a/src/services/recipes.js
+++ b/src/services/recipes.js
@@ -26,6 +26,7 @@ export const getOwnRecipes = async (userId, page = 1, perPage = 12) => {
   const [totalItems, data] = await Promise.all([
     RecipeCollections.countDocuments(query),
     RecipeCollections.find(query)
+      .populate('ingredients.id', '-__v')
       .sort({ createdAt: -1 })
       .skip(skip)
       .limit(perPage),
@@ -82,7 +83,13 @@ export const removeFavoriteRecipe = async (userId, recipeId) => {
   await user.save();
 };
 export const getFavoriteRecipes = async (userId) => {
-  const user = await UserModel.findById(userId).populate('favorites');
+  const user = await UserModel.findById(userId).populate({
+    path: 'favorites',
+    populate: {
+      path: 'ingredients.id',
+      select: '-__v',
+    },
+  });
 
   if (!user) {
     throw new createHttpError.NotFound('User not found');
@@ -124,6 +131,7 @@ export const getPaginatedRecipes = async ({
   const [totalItems, data] = await Promise.all([
     RecipeCollections.countDocuments(filter),
     recipeQuery
+      .populate('ingredients.id', '-__v')
       .sort({ [sortBy]: sortOrder })
       .skip(skip)
       .limit(perPage),


### PR DESCRIPTION
###  Що було зроблено:
- Додано `.populate('ingredients.id', '-__v')` у всі сервісні функції для рецептів
- Виправлено проблему з null значеннями інгредієнтів у відповідях API

###  Зміни у `src/services/recipes.js`:

**Функції з доданим populate:**
- `getRecipeById()` 
- `getOwnRecipes()` 
- `getFavoriteRecipes()` - (вкладений populate)
- `getPaginatedRecipes()` 

###  Результат:
Тепер всі ендпоінти рецептів повертають повну інформацію про інгредієнти (назва, опис, зображення) замість порожніх об'єктів.